### PR TITLE
Release 2.1.0 - add more workspace attributes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: goreleaser
+
+on:
+  pull_request:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-help:
-	@echo "To build, run \"goreleaser release --snapshot --skip-publish\" or for a full release push a new tag to \"origin\"."
+builddist:
+	goreleaser release --snapshot --skip-publish
 
 test:
 	go test -cover

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-builddist:
-	gox -osarch="linux/amd64 linux/arm darwin/amd64 windows/amd64" -output="dist/{{.OS}}/{{.Arch}}/tfc-ops"
+help:
+	@echo "To build, run \"goreleaser release --snapshot --skip-publish\" or for a full release push a new tag to \"origin\"."
 
 test:
 	go test -cover

--- a/cmd/workspacesUpdate.go
+++ b/cmd/workspacesUpdate.go
@@ -17,9 +17,11 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
 
 	"github.com/silinternational/tfc-ops/lib"
-	"github.com/spf13/cobra"
 )
 
 const (
@@ -50,7 +52,8 @@ func init() {
 	workspaceCmd.AddCommand(workspaceUpdateCmd)
 
 	workspaceUpdateCmd.Flags().StringVarP(&attribute, flagAttribute, "a", "",
-		requiredPrefix+"Workspace attribute to update. Available options: terraform-version")
+		requiredPrefix+"Workspace attribute to update. Available options: "+
+			strings.Join(lib.WorkspaceUpdateAttributes, ", "))
 	workspaceUpdateCmd.Flags().StringVarP(&value, flagValue, "v", "",
 		requiredPrefix+"Value")
 	workspaceUpdateCmd.Flags().StringVarP(&workspaceFilter, flagWorkspaceFilter, "w", "",


### PR DESCRIPTION
### Added
- Added `created-at`, `structured-run-output-enabled`, `terraform-version`, `vcs-repo.display-identifier`, `vcs-repo-oauth-token-id` attributes to "workspaces list" command
- Added `structured-run-output`, `vcs-repo.oauth-token-id` to "workspaces update" command
### Deprecated
- Deprecated `createdat`, `workingdirectory`, `terraformversion`, `vcsrepo` on "workspaces list" command to use attribute names that exactly match the names in the Terraform API. This would make it easier to programmatically reference attribute names, and full support for all workspace attributes
### Fixed
- By including `vcs-repo.display-identifier` this also addresses issue #29.