### PR TITLE
Add --suppress-header argument to list workspace/variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Flags:
 Global Flags:
   -o, --organization string   required - Name of Terraform Cloud Organization
   -r, --read-only-mode        read-only mode (e.g. "-r")
+  -s, --suppress-header       suppress the header from CSV output
 ```
 
 ### Workspace Update Help
@@ -226,6 +227,7 @@ Global Flags:
   -o, --organization string   required - Name of Terraform Cloud Organization
   -r, --read-only-mode        read-only mode (e.g. "-r")
   -w, --workspace string      Name of the Workspace in Terraform Cloud
+  -s, --suppress-header       suppress the header from CSV output
 ```
 
 ### Variables Update Help

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,10 +29,11 @@ import (
 const requiredPrefix = "required - "
 
 var (
-	cfgFile      string
-	organization string
-	readOnlyMode bool
-	errLog       *log.Logger
+	cfgFile      		string
+	organization 		string
+	readOnlyMode 		bool
+	suppressCSVHeader	bool
+	errLog       		*log.Logger
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -104,6 +105,10 @@ func addGlobalFlags(command *cobra.Command) {
 		`read-only mode (e.g. "-r")`,
 	)
 
+	command.PersistentFlags().BoolVarP(&suppressCSVHeader, "suppress-header", "s", false,
+		`suppress the header from CSV output`,
+	)
+
 	command.PersistentFlags().StringVarP(&organization, "organization",
 		"o", "", requiredPrefix+"Name of Terraform Cloud Organization")
 	if err := command.MarkPersistentFlagRequired("organization"); err != nil {
@@ -128,12 +133,20 @@ func workspaceListToString(wsNames []string) string {
 		return ""
 	}
 
-	s := ""
+	content := ""
+	header := ""
 	if len(wsNames) > 1 {
-		s = "workspaces: " + strings.Join(wsNames, ", ")
+		header = "workspaces: %s"
+		content = strings.Join(wsNames, ", ")
+		
 	} else {
-		s = "workspace '" + wsNames[0] + "'"
+		header = "workspace '%s'"
+		content = wsNames[0]
 	}
-
-	return s
+	
+	if suppressCSVHeader {
+		return content
+	} else {
+		return fmt.Sprintf(header, content)
+	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,11 +29,11 @@ import (
 const requiredPrefix = "required - "
 
 var (
-	cfgFile      		string
-	organization 		string
-	readOnlyMode 		bool
-	suppressCSVHeader	bool
-	errLog       		*log.Logger
+	cfgFile           string
+	organization      string
+	readOnlyMode      bool
+	suppressCSVHeader bool
+	errLog            *log.Logger
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -138,12 +138,12 @@ func workspaceListToString(wsNames []string) string {
 	if len(wsNames) > 1 {
 		header = "workspaces: %s"
 		content = strings.Join(wsNames, ", ")
-		
+
 	} else {
 		header = "workspace '%s'"
 		content = wsNames[0]
 	}
-	
+
 	if suppressCSVHeader {
 		return content
 	} else {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -46,31 +46,49 @@ func Test_workspaceListToString(t *testing.T) {
 	tests := []struct {
 		name           string
 		workspaceNames []string
+		suppressHeader bool
 		want           string
 	}{
 		{
 			name:           "nil",
 			workspaceNames: nil,
+			suppressHeader: false,
 			want:           "",
 		},
 		{
 			name:           "empty",
 			workspaceNames: []string{},
+			suppressHeader: false,
 			want:           "",
 		},
 		{
-			name:           "one",
+			name:           "one (header)",
 			workspaceNames: []string{"one"},
+			suppressHeader: false,
 			want:           "workspace 'one'",
 		},
 		{
-			name:           "two",
+			name:           "one (no header)",
+			workspaceNames: []string{"one"},
+			suppressHeader: true,
+			want:           "one",
+		},
+		{
+			name:           "two (header)",
 			workspaceNames: []string{"one", "two"},
+			suppressHeader: false,
 			want:           "workspaces: one, two",
+		},
+		{
+			name:           "two (no header)",
+			workspaceNames: []string{"one", "two"},
+			suppressHeader: true,
+			want:           "one, two",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			suppressCSVHeader = tt.suppressHeader
 			if got := workspaceListToString(tt.workspaceNames); got != tt.want {
 				t.Errorf("workspaceListToString() = %v, want %v", got, tt.want)
 			}

--- a/cmd/variablesList.go
+++ b/cmd/variablesList.go
@@ -44,7 +44,9 @@ var variablesListCmd = &cobra.Command{
 		}
 
 		if tabularCSV {
-			fmt.Println("workspace,key,value")
+			if !suppressCSVHeader {
+				fmt.Println("workspace,key,value")
+			}
 		} else {
 			keyMsg := ""
 			valMsg := ""

--- a/cmd/workspacesList.go
+++ b/cmd/workspacesList.go
@@ -32,7 +32,9 @@ var listCmd = &cobra.Command{
 	Long:  `Lists the TF workspaces with (some of) their attributes`,
 	Args:  cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Getting list of workspaces ...")
+		if !suppressCSVHeader {
+			fmt.Println("Getting list of workspaces ...")
+		}
 		runList()
 	},
 }


### PR DESCRIPTION
Added the global argument to suppress headers in variablesListCmd and workspaceListToString, updated README.md and Test_workspaceListToString