### PR TITLE
Release - fix goreleaser build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,11 +23,11 @@ gomod:
   proxy: true
 archives:
   -
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      amd64: x86_64
+    name_template: >-
+      tfc-ops_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
     format_overrides:
       - goos: windows
         format: zip


### PR DESCRIPTION
### Fixed
- Removed `replacements` option removed in [goreleaser 1.19](https://github.com/goreleaser/goreleaser/releases/tag/v1.19.0)