### PR TITLE
Release 3.5.4 -- fix workspaces clone

### DIFF
--- a/lib/client.go
+++ b/lib/client.go
@@ -586,25 +586,22 @@ func CreateAllVariables(organization, workspaceName string, tfVars []TFVar) {
 // GetCreateWorkspacePayload returns the JSON needed to make a POST to the
 // Terraform workspaces API
 func GetCreateWorkspacePayload(oc OpsConfig, vcsTokenID string) string {
-	return fmt.Sprintf(`
-{
-  "data": {
-    "attributes": {
-      "name": "%s",
-      "terraform_version": "%s",
-      "working-directory": "%s",
-      "vcs-repo": {
-        "identifier": "%s",
-        "oauth-token-id": "%s",
-        "branch": "%s",
-        "default-branch": true
-      }
-    },
-    "type": "workspaces"
-  }
+	jsonObj := gabs.Wrap(map[string]any{
+		"data": map[string]any{
+			"type": "workspaces",
+		},
+	})
+	_, _ = jsonObj.SetP(oc.NewName, "data.attributes.name")
+	_, _ = jsonObj.SetP(oc.TerraformVersion, "data.attributes.terraform_version")
+	_, _ = jsonObj.SetP(oc.Directory, "data.attributes.working-directory")
+	if vcsTokenID != "" {
+		_, _ = jsonObj.SetP(oc.RepoID, "data.attributes.vcs-repo.identifier")
+		_, _ = jsonObj.SetP(vcsTokenID, "data.attributes.vcs-repo.oauth-token-id")
+		_, _ = jsonObj.SetP(oc.Branch, "data.attributes.vcs-repo.branch")
+		_, _ = jsonObj.SetP(true, "data.attributes.vcs-repo.default-branch")
+	}
 
-}
-  `, oc.NewName, oc.TerraformVersion, oc.Directory, oc.RepoID, vcsTokenID, oc.Branch)
+	return jsonObj.String()
 }
 
 // UpdateVariable makes a Terraform vars API call to update a variable

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -1,0 +1,78 @@
+package lib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCreateWorkspacePayload(t *testing.T) {
+	assert := require.New(t)
+	tests := []struct {
+		name       string
+		oc         OpsConfig
+		vcsTokenID string
+		want       string
+	}{
+		{
+			name: "with VCS",
+			oc: OpsConfig{
+				NewName:          "new-name",
+				TerraformVersion: "version",
+				RepoID:           "repo-id",
+				Branch:           "branch",
+				Directory:        "directory",
+			},
+			vcsTokenID: "token-id",
+			want: `{
+  "data": {
+    "attributes": {
+      "name": "new-name",
+      "terraform_version": "version",
+      "vcs-repo": {
+        "branch": "branch",
+        "default-branch": true,
+        "identifier": "repo-id",
+        "oauth-token-id": "token-id"
+      },
+      "working-directory": "directory"
+    },
+    "type": "workspaces"
+  }
+} `,
+		},
+		{
+			name: "without VCS",
+			oc: OpsConfig{
+				NewName:          "new-name",
+				TerraformVersion: "version",
+				RepoID:           "repo-id",
+				Branch:           "branch",
+				Directory:        "directory",
+			},
+			vcsTokenID: "",
+			want: `{
+  "data": {
+    "attributes": {
+      "name": "new-name",
+      "terraform_version": "version",
+      "working-directory": "directory"
+    },
+    "type": "workspaces"
+  }
+} `,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetCreateWorkspacePayload(tt.oc, tt.vcsTokenID)
+			assert.Equal(removeWhitespace(tt.want), removeWhitespace(got))
+		})
+	}
+}
+
+func removeWhitespace(s string) string {
+	s1 := strings.ReplaceAll(s, " ", "")
+	return strings.ReplaceAll(s1, "\n", "")
+}


### PR DESCRIPTION
### Fixed
- Fixed `workspaces clone` command to omit the VCS config parameters if the token is not specified.