### PR TITLE
Release 4.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,6 @@ name: Test
 on:
   pull_request:
   push:
-    tags:
-      - '*'
 
 jobs:
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,11 +23,11 @@ gomod:
   proxy: true
 archives:
   -
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      amd64: x86_64
+    name_template: >-
+      tfc-ops_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
     format_overrides:
       - goos: windows
         format: zip

--- a/go.mod
+++ b/go.mod
@@ -7,16 +7,19 @@ require (
 	github.com/manifoldco/promptui v0.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0
+	github.com/stretchr/testify v1.8.1
 )
 
 require (
 	github.com/chzyer/readline v1.5.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.7 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/lib/client.go
+++ b/lib/client.go
@@ -586,25 +586,22 @@ func CreateAllVariables(organization, workspaceName string, tfVars []TFVar) {
 // GetCreateWorkspacePayload returns the JSON needed to make a POST to the
 // Terraform workspaces API
 func GetCreateWorkspacePayload(oc OpsConfig, vcsTokenID string) string {
-	return fmt.Sprintf(`
-{
-  "data": {
-    "attributes": {
-      "name": "%s",
-      "terraform_version": "%s",
-      "working-directory": "%s",
-      "vcs-repo": {
-        "identifier": "%s",
-        "oauth-token-id": "%s",
-        "branch": "%s",
-        "default-branch": true
-      }
-    },
-    "type": "workspaces"
-  }
+	jsonObj := gabs.Wrap(map[string]any{
+		"data": map[string]any{
+			"type": "workspaces",
+		},
+	})
+	_, _ = jsonObj.SetP(oc.NewName, "data.attributes.name")
+	_, _ = jsonObj.SetP(oc.TerraformVersion, "data.attributes.terraform_version")
+	_, _ = jsonObj.SetP(oc.Directory, "data.attributes.working-directory")
+	if vcsTokenID != "" {
+		_, _ = jsonObj.SetP(oc.RepoID, "data.attributes.vcs-repo.identifier")
+		_, _ = jsonObj.SetP(vcsTokenID, "data.attributes.vcs-repo.oauth-token-id")
+		_, _ = jsonObj.SetP(oc.Branch, "data.attributes.vcs-repo.branch")
+		_, _ = jsonObj.SetP(true, "data.attributes.vcs-repo.default-branch")
+	}
 
-}
-  `, oc.NewName, oc.TerraformVersion, oc.Directory, oc.RepoID, vcsTokenID, oc.Branch)
+	return jsonObj.String()
 }
 
 // UpdateVariable makes a Terraform vars API call to update a variable

--- a/lib/client.go
+++ b/lib/client.go
@@ -323,7 +323,7 @@ func OrganizationExists(organization string) (bool, error) {
 	defer resp.Body.Close()
 
 	// Status 200 indicates the organization exists
-	return resp.StatusCode == 200, nil
+	return resp.StatusCode == http.StatusOK, nil
 }
 
 // GetAllWorkspaces retrieves all workspaces from Terraform Cloud and returns a list of Workspace objects

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -1,0 +1,78 @@
+package lib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCreateWorkspacePayload(t *testing.T) {
+	assert := require.New(t)
+	tests := []struct {
+		name       string
+		oc         OpsConfig
+		vcsTokenID string
+		want       string
+	}{
+		{
+			name: "with VCS",
+			oc: OpsConfig{
+				NewName:          "new-name",
+				TerraformVersion: "version",
+				RepoID:           "repo-id",
+				Branch:           "branch",
+				Directory:        "directory",
+			},
+			vcsTokenID: "token-id",
+			want: `{
+  "data": {
+    "attributes": {
+      "name": "new-name",
+      "terraform_version": "version",
+      "vcs-repo": {
+        "branch": "branch",
+        "default-branch": true,
+        "identifier": "repo-id",
+        "oauth-token-id": "token-id"
+      },
+      "working-directory": "directory"
+    },
+    "type": "workspaces"
+  }
+} `,
+		},
+		{
+			name: "without VCS",
+			oc: OpsConfig{
+				NewName:          "new-name",
+				TerraformVersion: "version",
+				RepoID:           "repo-id",
+				Branch:           "branch",
+				Directory:        "directory",
+			},
+			vcsTokenID: "",
+			want: `{
+  "data": {
+    "attributes": {
+      "name": "new-name",
+      "terraform_version": "version",
+      "working-directory": "directory"
+    },
+    "type": "workspaces"
+  }
+} `,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetCreateWorkspacePayload(tt.oc, tt.vcsTokenID)
+			assert.Equal(removeWhitespace(tt.want), removeWhitespace(got))
+		})
+	}
+}
+
+func removeWhitespace(s string) string {
+	s1 := strings.ReplaceAll(s, " ", "")
+	return strings.ReplaceAll(s1, "\n", "")
+}

--- a/lib/run.go
+++ b/lib/run.go
@@ -38,34 +38,3 @@ func buildRunPayload(message, workspaceID string) string {
 
 	return data.String()
 }
-
-type RunTriggerConfig struct {
-	WorkspaceID       string
-	SourceWorkspaceID string
-}
-
-func CreateRunTrigger(config RunTriggerConfig) error {
-	u := NewTfcUrl("/workspaces/" + config.WorkspaceID + "/run-triggers")
-	payload := buildRunTriggerPayload(config.SourceWorkspaceID)
-	_ = callAPI(http.MethodPost, u.String(), payload, nil)
-	return nil
-}
-
-func buildRunTriggerPayload(sourceWorkspaceID string) string {
-	data := gabs.New()
-
-	_, err := data.Object("data")
-	if err != nil {
-		return "unable to create run trigger payload:" + err.Error()
-	}
-
-	workspaceObject := gabs.Wrap(map[string]any{
-		"type": "workspaces",
-		"id":   sourceWorkspaceID,
-	})
-	if _, err = data.SetP(workspaceObject, "data.relationships.sourceable.data"); err != nil {
-		return "unable to complete run trigger payload:" + err.Error()
-	}
-
-	return data.String()
-}

--- a/lib/run.go
+++ b/lib/run.go
@@ -38,3 +38,34 @@ func buildRunPayload(message, workspaceID string) string {
 
 	return data.String()
 }
+
+type RunTriggerConfig struct {
+	WorkspaceID       string
+	SourceWorkspaceID string
+}
+
+func CreateRunTrigger(config RunTriggerConfig) error {
+	u := NewTfcUrl("/workspaces/" + config.WorkspaceID + "/run-triggers")
+	payload := buildRunTriggerPayload(config.SourceWorkspaceID)
+	_ = callAPI(http.MethodPost, u.String(), payload, nil)
+	return nil
+}
+
+func buildRunTriggerPayload(sourceWorkspaceID string) string {
+	data := gabs.New()
+
+	_, err := data.Object("data")
+	if err != nil {
+		return "error"
+	}
+
+	if _, err = data.SetP(sourceWorkspaceID, "data.relationships.sourceable.data.id"); err != nil {
+		return "unable to process attribute for update:" + err.Error()
+	}
+
+	if _, err = data.SetP("workspaces", "data.relationships.sourceable.data.type"); err != nil {
+		return "unable to process attribute for update:" + err.Error()
+	}
+
+	return data.String()
+}

--- a/lib/run.go
+++ b/lib/run.go
@@ -25,15 +25,15 @@ func buildRunPayload(message, workspaceID string) string {
 
 	_, err := data.Object("data")
 	if err != nil {
-		return "error"
+		return "unable to create run payload:" + err.Error()
 	}
 
 	if _, err = data.SetP(message, "data.attributes.message"); err != nil {
-		return "unable to process attribute for update:" + err.Error()
+		return "unable to process message for run payload:" + err.Error()
 	}
 
 	if _, err = data.SetP(workspaceID, "data.relationships.workspace.data.id"); err != nil {
-		return "unable to process attribute for update:" + err.Error()
+		return "unable to process workspace ID for run payload:" + err.Error()
 	}
 
 	return data.String()
@@ -56,15 +56,15 @@ func buildRunTriggerPayload(sourceWorkspaceID string) string {
 
 	_, err := data.Object("data")
 	if err != nil {
-		return "error"
+		return "unable to create run trigger payload:" + err.Error()
 	}
 
-	if _, err = data.SetP(sourceWorkspaceID, "data.relationships.sourceable.data.id"); err != nil {
-		return "unable to process attribute for update:" + err.Error()
-	}
-
-	if _, err = data.SetP("workspaces", "data.relationships.sourceable.data.type"); err != nil {
-		return "unable to process attribute for update:" + err.Error()
+	workspaceObject := gabs.Wrap(map[string]any{
+		"type": "workspaces",
+		"id":   sourceWorkspaceID,
+	})
+	if _, err = data.SetP(workspaceObject, "data.relationships.sourceable.data"); err != nil {
+		return "unable to complete run trigger payload:" + err.Error()
 	}
 
 	return data.String()

--- a/lib/run.go
+++ b/lib/run.go
@@ -11,6 +11,8 @@ type RunConfig struct {
 	WorkspaceID string
 }
 
+// CreateRun creates a Run, which starts a Plan, which can later be Applied.
+// https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run
 func CreateRun(config RunConfig) error {
 	u := NewTfcUrl("/runs")
 	payload := buildRunPayload(config.Message, config.WorkspaceID)

--- a/lib/run_test.go
+++ b/lib/run_test.go
@@ -10,3 +10,10 @@ func Test_buildRunPayload(t *testing.T) {
 		t.Fatalf("did not get expected result, got %q", got)
 	}
 }
+
+func Test_buildRunTriggerPayload(t *testing.T) {
+	got := buildRunTriggerPayload("ws_id")
+	if got != `{"data":{"relationships":{"sourceable":{"data":{"id":"ws_id","type":"workspaces"}}}}}` {
+		t.Fatalf("did not get expected result, got %q", got)
+	}
+}

--- a/lib/run_test.go
+++ b/lib/run_test.go
@@ -7,13 +7,13 @@ import (
 func Test_buildRunPayload(t *testing.T) {
 	got := buildRunPayload("my message", "ws_id")
 	if got != `{"data":{"attributes":{"message":"my message"},"relationships":{"workspace":{"data":{"id":"ws_id"}}}}}` {
-		t.Fatalf("did not get expected result, got %q", got)
+		t.Fatalf("did not get expected result, got %s", got)
 	}
 }
 
 func Test_buildRunTriggerPayload(t *testing.T) {
 	got := buildRunTriggerPayload("ws_id")
 	if got != `{"data":{"relationships":{"sourceable":{"data":{"id":"ws_id","type":"workspaces"}}}}}` {
-		t.Fatalf("did not get expected result, got %q", got)
+		t.Fatalf("did not get expected result, got %s", got)
 	}
 }

--- a/lib/run_test.go
+++ b/lib/run_test.go
@@ -10,10 +10,3 @@ func Test_buildRunPayload(t *testing.T) {
 		t.Fatalf("did not get expected result, got %s", got)
 	}
 }
-
-func Test_buildRunTriggerPayload(t *testing.T) {
-	got := buildRunTriggerPayload("ws_id")
-	if got != `{"data":{"relationships":{"sourceable":{"data":{"id":"ws_id","type":"workspaces"}}}}}` {
-		t.Fatalf("did not get expected result, got %s", got)
-	}
-}

--- a/lib/runtrigger.go
+++ b/lib/runtrigger.go
@@ -1,0 +1,110 @@
+package lib
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/Jeffail/gabs/v2"
+)
+
+type RunTriggerConfig struct {
+	WorkspaceID       string
+	SourceWorkspaceID string
+}
+
+func CreateRunTrigger(config RunTriggerConfig) error {
+	u := NewTfcUrl("/workspaces/" + config.WorkspaceID + "/run-triggers")
+	payload := buildRunTriggerPayload(config.SourceWorkspaceID)
+	_ = callAPI(http.MethodPost, u.String(), payload, nil)
+	return nil
+}
+
+func buildRunTriggerPayload(sourceWorkspaceID string) string {
+	data := gabs.New()
+	_, err := data.Object("data")
+	if err != nil {
+		return "unable to create run trigger payload:" + err.Error()
+	}
+
+	workspaceObject := gabs.Wrap(map[string]any{
+		"type": "workspaces",
+		"id":   sourceWorkspaceID,
+	})
+	if _, err = data.SetP(workspaceObject, "data.relationships.sourceable.data"); err != nil {
+		return "unable to complete run trigger payload:" + err.Error()
+	}
+
+	return data.String()
+}
+
+type FindRunTriggerConfig struct {
+	SourceID    string
+	WorkspaceID string
+}
+
+// FindRunTrigger searches all the run triggers inbound to the given WorkspaceID. If a run trigger is configured for
+// the given SourceID, that trigger is returned. Otherwise, nil is returned.
+func FindRunTrigger(config FindRunTriggerConfig) (*RunTrigger, error) {
+	triggers, err := ListRunTriggers(ListRunTriggerConfig{
+		WorkspaceID: config.WorkspaceID,
+		Type:        "inbound",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list run triggers: %w", err)
+	}
+	for _, t := range triggers {
+		if t.SourceID == config.SourceID {
+			return &t, nil
+		}
+	}
+	return nil, nil
+}
+
+type RunTrigger struct {
+	CreatedAt     time.Time
+	SourceName    string
+	SourceID      string
+	WorkspaceName string
+	WorkspaceID   string
+}
+
+type ListRunTriggerConfig struct {
+	WorkspaceID string
+	Type        string // must be either "inbound" or "outbound"
+}
+
+// ListRunTriggers returns a list of run triggers configured for the given workspace
+// https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run-triggers#list-run-triggers
+func ListRunTriggers(config ListRunTriggerConfig) ([]RunTrigger, error) {
+	u := NewTfcUrl("/workspaces/" + config.WorkspaceID + "/run-triggers?filter%5Brun-trigger%5D%5Btype%5D=" + config.Type)
+	resp := callAPI(http.MethodGet, u.String(), "", nil)
+	triggers, err := parseRunTriggerListResponse(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return triggers, nil
+}
+
+func parseRunTriggerListResponse(r io.Reader) ([]RunTrigger, error) {
+	parsed, err := gabs.ParseJSONBuffer(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse response data: %w", err)
+	}
+
+	attributes := parsed.Search("data", "*").Children()
+	triggers := make([]RunTrigger, len(attributes))
+	for i, attr := range attributes {
+		trigger := RunTrigger{
+			SourceID:      attr.Path("relationships.sourceable.data.id").Data().(string),
+			SourceName:    attr.Path("attributes.sourceable-name").Data().(string),
+			WorkspaceID:   attr.Path("relationships.workspace.data.id").Data().(string),
+			WorkspaceName: attr.Path("attributes.workspace-name").Data().(string),
+		}
+		createdAt, _ := time.Parse(time.RFC3339, attr.Path("attributes.created-at").Data().(string))
+		trigger.CreatedAt = createdAt
+		triggers[i] = trigger
+	}
+	return triggers, nil
+}

--- a/lib/runtrigger.go
+++ b/lib/runtrigger.go
@@ -40,12 +40,12 @@ func buildRunTriggerPayload(sourceWorkspaceID string) string {
 }
 
 type FindRunTriggerConfig struct {
-	SourceID    string
-	WorkspaceID string
+	SourceWorkspaceID string
+	WorkspaceID       string
 }
 
 // FindRunTrigger searches all the run triggers inbound to the given WorkspaceID. If a run trigger is configured for
-// the given SourceID, that trigger is returned. Otherwise, nil is returned.
+// the given SourceWorkspaceID, that trigger is returned. Otherwise, nil is returned.
 func FindRunTrigger(config FindRunTriggerConfig) (*RunTrigger, error) {
 	triggers, err := ListRunTriggers(ListRunTriggerConfig{
 		WorkspaceID: config.WorkspaceID,
@@ -55,7 +55,7 @@ func FindRunTrigger(config FindRunTriggerConfig) (*RunTrigger, error) {
 		return nil, fmt.Errorf("failed to list run triggers: %w", err)
 	}
 	for _, t := range triggers {
-		if t.SourceID == config.SourceID {
+		if t.SourceID == config.SourceWorkspaceID {
 			return &t, nil
 		}
 	}

--- a/lib/runtrigger.go
+++ b/lib/runtrigger.go
@@ -78,7 +78,9 @@ type ListRunTriggerConfig struct {
 // ListRunTriggers returns a list of run triggers configured for the given workspace
 // https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run-triggers#list-run-triggers
 func ListRunTriggers(config ListRunTriggerConfig) ([]RunTrigger, error) {
-	u := NewTfcUrl("/workspaces/" + config.WorkspaceID + "/run-triggers?filter%5Brun-trigger%5D%5Btype%5D=" + config.Type)
+	u := NewTfcUrl("/workspaces/" + config.WorkspaceID + "/run-triggers")
+	u.SetParam(paramFilterRunTriggerType, config.Type)
+
 	resp := callAPI(http.MethodGet, u.String(), "", nil)
 	triggers, err := parseRunTriggerListResponse(resp.Body)
 	if err != nil {

--- a/lib/runtrigger_test.go
+++ b/lib/runtrigger_test.go
@@ -1,0 +1,55 @@
+package lib
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_buildRunTriggerPayload(t *testing.T) {
+	got := buildRunTriggerPayload("ws_id")
+	if got != `{"data":{"relationships":{"sourceable":{"data":{"id":"ws_id","type":"workspaces"}}}}}` {
+		t.Fatalf("did not get expected result, got %s", got)
+	}
+}
+
+func Test_parseRunTriggerListResponse(t *testing.T) {
+	r := bytes.NewReader([]byte(listTriggerSampleBody))
+	triggers, err := parseRunTriggerListResponse(r)
+	require.NoError(t, err)
+	require.Equal(t, triggers[0].WorkspaceID, "ws-abcdefghijklmnop")
+	require.Equal(t, triggers[0].SourceID, "ws-qrstuvwxyzABCDEF")
+	require.Equal(t, triggers[0].WorkspaceName, "a-workspace-name")
+	require.Equal(t, triggers[0].SourceName, "source-ws-1")
+	require.Equal(t, triggers[0].CreatedAt, time.Date(2023, 6, 20, 8, 56, 50, 996e6, time.UTC))
+}
+
+const listTriggerSampleBody = `{
+	"data": [
+		{
+			"id": "rt-abcdefghijklmnop",
+			"type": "run-triggers",
+			"attributes": {
+				"workspace-name": "a-workspace-name",
+				"sourceable-name": "source-ws-1",
+				"created-at": "2023-06-20T08:56:50.996Z"
+			},
+			"relationships": {
+				"workspace": {
+					"data": {
+						"id": "ws-abcdefghijklmnop",
+						"type": "workspaces"
+					}
+				},
+				"sourceable": {
+					"data": {
+						"id": "ws-qrstuvwxyzABCDEF",
+						"type": "workspaces"
+					}
+				}
+			}
+		}
+	]
+}`

--- a/lib/url.go
+++ b/lib/url.go
@@ -14,6 +14,7 @@ const (
 	paramFilterWorkspaceName    = "filter[workspace][name]"
 	paramPageSize               = "page[size]"
 	paramPageNumber             = "page[number]"
+	paramFilterRunTriggerType   = "filter[run-trigger][type]"
 	paramSearchName             = "search[name]"
 )
 
@@ -21,6 +22,7 @@ type TfcUrl struct {
 	url.URL
 }
 
+// NewTfcUrl creates a url.URL object for the Terraform Cloud API.
 func NewTfcUrl(path string) TfcUrl {
 	newURL, _ := url.Parse(baseURL + path)
 	v := url.Values{}

--- a/lib/url_test.go
+++ b/lib/url_test.go
@@ -1,0 +1,15 @@
+package lib
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTfcUrl(t *testing.T) {
+	orgs := NewTfcUrl("/organizations")
+	require.Equal(t, baseURL+"/organizations", orgs.String())
+
+	withQuery := NewTfcUrl("/organizations?q=foo")
+	require.Equal(t, baseURL+"/organizations", withQuery.String())
+}


### PR DESCRIPTION
### Added
- Use API token in dotfiles ([ITSE-1492](https://itse.youtrack.cloud/issue/ITSE-1492)) (Resolves #54)

### Changed
- CallApi returns an error instead of panic

### Removed
- Deleted commented out code
- Removed TFVars struct as it was a strict subset of the Vars struct.
- Removed deprecated `--dry-run-mode` flag