### PR TITLE
upgrade GitHub actions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -8,7 +8,7 @@ jobs:
     name: Update changelog
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         ref: main
     - uses: rhysd/changelog-from-release/action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,6 @@ jobs:
       uses: goreleaser/goreleaser-action@v7
       if: github.event.pull_request
       with:
-        version: '~> v1'
         args: release --snapshot --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,32 +13,31 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-    -
-      name: Checkout
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-    -
-      name: Fetch all tags
-      run: git fetch --force --tags
-    -
-      name: Set up Go
-      uses: actions/setup-go@v6
-      with:
-        go-version-file: 'go.mod'
-    -
-      name: Run GoReleaser in snapshot mode
-      uses: goreleaser/goreleaser-action@v7
-      if: github.event.pull_request
-      with:
-        args: release --snapshot --clean
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    -
-      name: Run GoReleaser on a release tag
-      uses: goreleaser/goreleaser-action@v7
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        args: release --clean
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Fetch all tags
+        run: git fetch --force --tags
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Run GoReleaser in snapshot mode
+        uses: goreleaser/goreleaser-action@v7
+        if: github.event.pull_request
+        with:
+          args: release --snapshot --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser on a release tag
+        uses: goreleaser/goreleaser-action@v7
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     -
       name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
     -
@@ -23,12 +23,12 @@ jobs:
       run: git fetch --force --tags
     -
       name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: 'go.mod'
     -
       name: Run GoReleaser in snapshot mode
-      uses: goreleaser/goreleaser-action@v5
+      uses: goreleaser/goreleaser-action@v7
       if: github.event.pull_request
       with:
         version: '~> v1'
@@ -37,7 +37,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     -
       name: Run GoReleaser on a release tag
-      uses: goreleaser/goreleaser-action@v5
+      uses: goreleaser/goreleaser-action@v7
       if: startsWith(github.ref, 'refs/tags/')
       with:
         version: '~> v1'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ jobs:
       uses: goreleaser/goreleaser-action@v7
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        version: '~> v1'
         args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
         go-version: [ '1.25' ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,10 +1,19 @@
 # This is the configuration for goreleaser
-# Check the documentation at http://goreleaser.com for details
+# Check the documentation at https://goreleaser.com for details
+
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+
+version: 2
+
 before:
   hooks:
     - go mod tidy
+
 builds:
-  - env:
+  - id: tfc-ops
+    binary: tfc-ops
+    main: .
+    env:
       - CGO_ENABLED=0
     goos:
       - linux
@@ -17,24 +26,29 @@ builds:
       - goos: windows
         goarch: arm
     ldflags:
-    - -s -w
-    - -X '{{.ModulePath}}/cmd.version={{.Version}}'
+      - -s -w
+      - -X '{{.ModulePath}}/cmd.version={{.Version}}'
 gomod:
   proxy: true
 archives:
-  -
+  - formats: [tar.gz]
+    # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
-      tfc-ops_
+      {{ .ProjectName }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
+
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-dev"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
[ITSE-2562 Upgrade GitHub Action steps that are using Node 20](https://support.gtis.sil.org/issue/ITSE-2562)

---

### Changed
- Update actions version references to latest available to include support for Node 24.